### PR TITLE
included sequence IDs in repseq lengths file, no longer sorting by length

### DIFF
--- a/Snakefile_linux
+++ b/Snakefile_linux
@@ -378,7 +378,7 @@ rule repseq_length_distribution:
     output:
         "02-denoised/{method}/representative_sequences_lengths.txt"
     shell:
-        "perl scripts/fastaLengths.pl {input} | sort > {output}"
+        "perl scripts/fastaLengths.pl {input} > {output}"
 
 rule repseq_length_distribution_describe:
     input:
@@ -386,7 +386,7 @@ rule repseq_length_distribution_describe:
     output:
         "02-denoised/{method}/representative_sequences_lengths_describe.tsv"
     run:
-        s = pd.read_csv(input[0], header=None)
+        s = pd.read_csv(input[0], header=None, index_col=0)
         t = s.describe()
         t.to_csv(output[0], sep='\t', header='sequence_length_bp')
 

--- a/Snakefile_mac
+++ b/Snakefile_mac
@@ -378,7 +378,7 @@ rule repseq_length_distribution:
     output:
         "02-denoised/{method}/representative_sequences_lengths.txt"
     shell:
-        "perl scripts/fastaLengths.pl {input} | sort > {output}"
+        "perl scripts/fastaLengths.pl {input} > {output}"
 
 rule repseq_length_distribution_describe:
     input:
@@ -386,7 +386,7 @@ rule repseq_length_distribution_describe:
     output:
         "02-denoised/{method}/representative_sequences_lengths_describe.tsv"
     run:
-        s = pd.read_csv(input[0], header=None)
+        s = pd.read_csv(input[0], header=None, index_col=0)
         t = s.describe()
         t.to_csv(output[0], sep='\t', header='sequence_length_bp')
 

--- a/scripts/fastaLengths.pl
+++ b/scripts/fastaLengths.pl
@@ -7,7 +7,8 @@ my $usage = qq{
         <infile>: multi-FASTA file with or without line breaks
 
         This script takes a multi-fasta file with or without line breaks and
-        prints the number of bases in each sequence to standard output.
+        prints the sequence header (up to the first space) and number of bases
+        in each sequence, comma-delimited (.csv), to standard output.
 
 
 };
@@ -32,20 +33,27 @@ foreach my $line (@fasta) {
     } elsif ($line =~ /^\s*#/) {
         next;
 
-    # Discard header line but print previous length and initialize length
+    # Store header line. If previous length exists, print previous length and
+    # next header, else print (first) header. Initialize length.
     } elsif ($line =~ /^>[a-zA-Z0-9]*/) {
-	if ($length) { print "$length\n"; }
+        $header = $line =~ s/>([a-zA-Z0-9]*).*\n/$1/r;
+        if ($length) {
+            print "$length\n";
+            print "$header,";
+        } else {
+            print "$header,";
+        }
         $length = 0;
-	next;
+        next;
 
-    # Keep sequence line, count bases, print
+    # Keep sequence line, add bases to length
     } else {
         chomp $line;
-	$length += length($line);
+        $length += length($line);
     }
 }
 
-#print last fasta length
+# Print last fasta length
 print "$length\n";
 
 exit;


### PR DESCRIPTION
Having repseq IDs linked to their lengths will assist in filtering of repseqs.